### PR TITLE
Fix preg_replace(): Passing null to parameter #3 ($subject) of type a…

### DIFF
--- a/lib/net/authorize/util/Log.php
+++ b/lib/net/authorize/util/Log.php
@@ -102,7 +102,7 @@ class Log
             $patterns [$i] = $pattern;
             $replacements[$i]  = $replacement;
         }
-        $maskedString = preg_replace($patterns, $replacements, $rawString);
+        $maskedString = preg_replace($patterns, $replacements, $rawString ?? '');
         return $maskedString;
     }
 
@@ -163,7 +163,7 @@ class Log
             }
 
             if(strcmp($prop->getName(), $sensitiveField->tagName) == 0) {
-                $prop->setValue($obj, preg_replace($inputPattern, $inputReplacement, $prop->getValue($obj)));
+                $prop->setValue($obj, preg_replace($inputPattern, $inputReplacement, $prop->getValue($obj) ?? ''));
                 return $prop->getValue($obj);
             }
         }


### PR DESCRIPTION
…rray|string is deprecated /var/app/current/vendor/authorizenet/authorizenet/lib/net/authorize/util/Log.php:166